### PR TITLE
Update INSTALL.md with the right version of rocksdb

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,7 @@ by [grocksdb](https://github.com/linxGnu/grocksdb#prerequisite) and
 
 To build RocksDB from source, run the following commands:
 
-    git clone https://github.com/facebook/rocksdb --branch v7.10.2 --depth 1
+    git clone https://github.com/facebook/rocksdb --branch v9.7.3 --depth 1
     cd rocksdb
     mkdir -p build && cd build
     cmake .. \


### PR DESCRIPTION
We are using the version v1.9.7 of the grocksdb https://github.com/rpcpool/radiance-triton-faithful/blob/b162768e2e94dd1a30afa73de50267f5392b8d8d/go.mod#L31C2-L31C29 and this version only supports the version v9.7.3 of rocksdb, see: https://github.com/linxGnu/grocksdb/compare/v1.9.6...v1.9.7